### PR TITLE
fix(database): bypass URL parsing for Railway.com placeholder URLs

### DIFF
--- a/alo_backend/app/main.py
+++ b/alo_backend/app/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
@@ -16,13 +17,59 @@ async def lifespan(app: FastAPI):
     print("Shutting down ALO API...")
 
 def create_application() -> FastAPI:
+    # Determine if we're in a production environment
+    is_production = os.getenv("RAILWAY_ENVIRONMENT") == "production"
+    
+    # Check if we're using a placeholder database URL (Railway.com specific issue)
+    db_url = settings.DATABASE_URL
+    using_fallback_db = 'hostname' in db_url or 'port' in db_url
+    
+    # Configure OpenAPI with proper server URLs for different environments
+    if is_production:
+        # In production, dynamically set the server URL
+        service_url = os.getenv("RAILWAY_PUBLIC_DOMAIN", "lifey-production.up.railway.app")
+        servers = [
+            {"url": f"https://{service_url}", "description": "Production server"}
+        ]
+    else:
+        # In development, support multiple ports
+        servers = [
+            {"url": "http://localhost:8000", "description": "Development server - port 8000"},
+            {"url": "http://localhost:8080", "description": "Development server - port 8080"}
+        ]
+    
+    # Set documentation description based on database status
+    if using_fallback_db:
+        description = """
+        # ⚠️ WARNING: DOCUMENTATION MODE ONLY ⚠️
+        
+        The application is running with a fallback in-memory database because a proper DATABASE_URL 
+        has not been configured in the environment variables.
+        
+        **API calls requiring database access will not work until a valid DATABASE_URL is provided.**
+        
+        ## Configuration Instructions
+        
+        1. Set the DATABASE_URL environment variable in your Railway.com project settings
+        2. Use a valid PostgreSQL connection string format: `postgresql://username:password@hostname:port/database`
+        3. Restart the application after setting the environment variable
+        
+        ## Automated Life Organizer API
+        
+        Documentation is available at /docs regardless of the port.
+        """
+    else:
+        description = "Automated Life Organizer API - Documentation is available at /docs regardless of the port."
+    
     app = FastAPI(
         title=settings.PROJECT_NAME,
-        description="Automated Life Organizer API",
+        description=description,
         version="0.1.0",
         docs_url="/docs",
         redoc_url="/redoc",
-        lifespan=lifespan
+        lifespan=lifespan,
+        openapi_url="/openapi.json",
+        servers=servers
     )
 
     # CORS middleware


### PR DESCRIPTION
## 🚀 Documentation Mode for Railway.com Deployments

This PR implements a robust solution for the Railway.com placeholder URL issue that allows the application to run in a documentation-only mode when proper database credentials aren't available.

### 🐛 Issues Fixed
1. **Critical Error Fixed**: Resolved the `invalid literal for int() with base 10: 'port'` error that appears when Railway.com provides placeholder values
2. **Documentation Access**: Ensured Swagger documentation is accessible even when the database is unavailable
3. **Port Configuration**: Updated port handling to use 8080 consistently across all environments

### 🔧 Implementation Details
1. **SQLite Memory Fallback**: 
   - Added detection for Railway.com placeholder URLs (`hostname`, `port`)
   - Automatically switches to in-memory SQLite database when placeholders are detected
   - Allows application to start without crashing

2. **Clear Documentation Mode**:
   - Added prominent warning banner in Swagger UI when running in fallback mode
   - Provided clear instructions for setting proper DATABASE_URL
   - Ensured all documentation endpoints remain accessible

3. **Enhanced Configuration**:
   - Added proper server URLs in OpenAPI specification
   - Improved logging with meaningful messages about database status

### 📝 Compliance
- Follows ALO Project Development Rules section 11 (Error Handling) with proper fallback mechanisms
- Implements section 7 (Documentation) requirements for accessible API documentation
- Follows Semantic Seed Coding Standards V2.0 for error management and user experience

### 🚦 Next Steps
Once merged, this PR will:
1. Ensure documentation is accessible at `https://lifey-production.up.railway.app/docs`
2. Provide clear instructions for configuring the real database URL
3. Make the application more resilient to configuration issues

The application will still need a proper DATABASE_URL to be fully functional, but users will be able to access the documentation and understand what needs to be configured.