### PR TITLE
fix(env): handle malformed DATABASE_URL format

### DIFF
--- a/alo_backend/app/core/config.py
+++ b/alo_backend/app/core/config.py
@@ -34,6 +34,13 @@ def validate_database_url(v: Optional[str]) -> str:
         logger.warning(f"No DATABASE_URL provided, using default: {default_url.replace('postgres:postgres', 'postgres:****')}")
         return default_url
     
+    # Handle the case where Railway.com includes the variable name in the value
+    # Example: 'DATABASE_URL=postgresql://postgres:postgres@localhost:5432/alodb'
+    if v.startswith('DATABASE_URL='):
+        logger.warning("Detected variable name in DATABASE_URL value, stripping prefix")
+        v = v.replace('DATABASE_URL=', '', 1)
+        logger.info(f"Corrected DATABASE_URL format")
+    
     # Special handling for Railway.com placeholder format
     # Railway might provide URLs with placeholders like postgresql://user:pass@hostname:port/database
     if '@hostname:port/' in v or 'hostname' in v or 'port' in v:

--- a/alo_backend/app/core/database.py
+++ b/alo_backend/app/core/database.py
@@ -17,9 +17,18 @@ logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
-# Check if this is a Railway.com deployment with placeholder URL
+# Check if this is a Railway.com deployment with placeholder URL or malformed URL
 db_url = settings.DATABASE_URL
 use_fallback = False
+
+# Handle the case where Railway.com includes the variable name in the value
+# Example: 'DATABASE_URL=postgresql://postgres:postgres@localhost:5432/alodb'
+if db_url.startswith('DATABASE_URL='):
+    logger.warning("Detected variable name in DATABASE_URL value, stripping prefix")
+    db_url = db_url.replace('DATABASE_URL=', '', 1)
+    # Update the settings value as well
+    settings.DATABASE_URL = db_url
+    logger.info(f"Corrected DATABASE_URL format")
 
 # Detect Railway.com placeholder format
 if 'hostname' in db_url or 'port' in db_url:


### PR DESCRIPTION
## 🛠️ Environment Variable Format Fix

This PR addresses the specific issue where Railway.com is including the variable name in the DATABASE_URL value, causing SQLAlchemy errors like:

```
sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from string 'DATABASE_URL=postgresql://postgres:postgres@localhost:5432/alodb'
```

### 🐛 Issue Fixed
The application was failing because Railway.com is including the variable name in the actual value, resulting in an invalid SQLAlchemy URL format:
- Incorrect format: `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/alodb`
- Expected format: `postgresql://postgres:postgres@localhost:5432/alodb`

### 🔧 Implementation Details
1. **Variable Name Detection**:
   - Added checks to detect and strip the `DATABASE_URL=` prefix from connection strings
   - Implemented in both `config.py` and `database.py` for redundancy
   - Ensures consistency between validation and engine creation

2. **Improved Logging**:
   - Added more detailed logs when this specific issue is detected
   - Provides clear information about the format correction
   - Helps with troubleshooting Railway.com deployments

### 📝 Compliance
- Follows ALO Project Development Rules section 11 (Error Handling) with robust error detection
- Aligns with Semantic Seed Coding Standards V2.0 for error management
- Implements multiple fallback mechanisms as required by development standards

### 🚦 Impact
This fix addresses a critical deployment issue that prevents the application from starting in Railway.com when environment variables are provided in this specific format, and should be merged immediately.